### PR TITLE
@EnableAbac overwrites the root resource info method argument resolver

### DIFF
--- a/thunx-spring/src/main/java/eu/xenit/contentcloud/thunx/spring/data/rest/AbacConfiguration.java
+++ b/thunx-spring/src/main/java/eu/xenit/contentcloud/thunx/spring/data/rest/AbacConfiguration.java
@@ -7,10 +7,20 @@ import eu.xenit.contentcloud.thunx.encoding.json.ExpressionJsonConverter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import javax.persistence.EntityManager;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.querydsl.binding.AbacQuerydslPredicateBuilder;
+import org.springframework.data.querydsl.binding.QuerydslBindingsFactory;
 import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.repository.support.RepositoryInvokerFactory;
+import org.springframework.data.rest.webmvc.config.ResourceMetadataHandlerMethodArgumentResolver;
+import org.springframework.data.rest.webmvc.config.RootResourceInformationHandlerMethodArgumentResolver;
+import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
@@ -51,4 +61,35 @@ public class AbacConfiguration {
         return registrationBean;
     }
 
+    @Bean
+    public BeanPostProcessor interceptRepositoryRestMvcConfiguration(ApplicationContext applicationContext)
+    {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+
+
+                if (bean instanceof RootResourceInformationHandlerMethodArgumentResolver) {
+                    var repositories = applicationContext.getBean(Repositories.class);
+                    var invokerFactory = applicationContext.getBean(RepositoryInvokerFactory.class);
+                    var resourceMetadataResolver = applicationContext.getBean(ResourceMetadataHandlerMethodArgumentResolver.class);
+                    var factory = applicationContext.getBean(QuerydslBindingsFactory.class);
+
+                    var defaultConversionService = new DefaultFormattingConversionService(); // ??
+                    var predicateBuilder = new AbacQuerydslPredicateBuilder(defaultConversionService, factory.getEntityPathResolver());
+
+
+                    return new AbacRootResourceInformationHandlerMethodArgumentResolver(
+                            repositories,
+                            invokerFactory,
+                            resourceMetadataResolver,
+                            predicateBuilder,
+                            factory
+                    );
+                }
+
+                return bean;
+            }
+        };
+    }
 }


### PR DESCRIPTION
- with the Abac variant ensuring any AbacContext is always applied to Spring Data Repsitory invocations