### PR TITLE
Make the AuthenticationContextMapper accept JWT AccessTokens too.

### DIFF
--- a/thunx-spring/src/main/java/eu/xenit/contentcloud/thunx/spring/security/AuthenticationContextMapper.java
+++ b/thunx-spring/src/main/java/eu/xenit/contentcloud/thunx/spring/security/AuthenticationContextMapper.java
@@ -8,6 +8,7 @@ import java.util.function.BiConsumer;
 import lombok.NonNull;
 import lombok.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.ClaimAccessor;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 
@@ -39,8 +40,8 @@ public class AuthenticationContextMapper {
         var result = new HashMap<String, Object>();
 
         var principal = authentication.getPrincipal();
-        if (principal instanceof OidcUser) {
-            result.put("claims", ((OidcUser) principal).getClaims());
+        if (principal instanceof ClaimAccessor) {
+            result.put("claims", ((ClaimAccessor) principal).getClaims());
         }
 
         return result;
@@ -62,6 +63,10 @@ public class AuthenticationContextMapper {
                 });
                 return result;
             }
+        }
+
+        if (principal instanceof ClaimAccessor) {
+            return ((ClaimAccessor) principal).getClaims();
         }
 
         // fallback to check authorities on the auth-object


### PR DESCRIPTION
By allowing a more generic authentication, this can be used for clients identifying themselves by a service account, authenticated by the OIDC Client-Credentials Grant.