### PR TITLE
Use spring-boot-dependencies platform for implementation dependency

### DIFF
--- a/thunx-autoconfigure/build.gradle
+++ b/thunx-autoconfigure/build.gradle
@@ -6,7 +6,7 @@ apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
 
-    compileOnly platform("org.springframework.boot:spring-boot-dependencies:${springBootBomVersion}")
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootBomVersion}")
     compileOnly platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}")
 
     implementation "org.springframework.boot:spring-boot-autoconfigure"


### PR DESCRIPTION
Because the platform was set for compileOnly, it was applied to
spring-boot-autoconfigure (on implementation) due to how inheritance
works.
However, when publishing the library, Gradle detected a problem with the
metadata because no platform was published (compileOnly configuration is
not published because it is only for internal compilation, not for
runtime or dependents compilation).

The easy fix to this problem is to actually use the platform in the
implementation configuration.