### PR TITLE
Add support for input.entity.property = null comparison.

### DIFF
--- a/thunx-predicates-querydsl/src/main/java/eu/xenit/contentcloud/thunx/predicates/querydsl/QueryDslConverter.java
+++ b/thunx-predicates-querydsl/src/main/java/eu/xenit/contentcloud/thunx/predicates/querydsl/QueryDslConverter.java
@@ -5,11 +5,11 @@ import com.querydsl.core.types.Operator;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
-import eu.xenit.contentcloud.thunx.predicates.model.ThunkExpressionVisitor;
 import eu.xenit.contentcloud.thunx.predicates.model.FunctionExpression;
 import eu.xenit.contentcloud.thunx.predicates.model.Scalar;
 import eu.xenit.contentcloud.thunx.predicates.model.SymbolicReference;
 import eu.xenit.contentcloud.thunx.predicates.model.SymbolicReference.PathElementVisitor;
+import eu.xenit.contentcloud.thunx.predicates.model.ThunkExpressionVisitor;
 import eu.xenit.contentcloud.thunx.predicates.model.Variable;
 
 class QueryDslConverter implements ThunkExpressionVisitor<Expression<?>> {
@@ -24,6 +24,9 @@ class QueryDslConverter implements ThunkExpressionVisitor<Expression<?>> {
 
     @Override
     public Expression<?> visit(Scalar<?> scalar) {
+        if(scalar == Scalar.nullValue()) {
+            return Expressions.nullExpression();
+        }
         return Expressions.constant(scalar.getValue());
     }
 

--- a/thunx-predicates-querydsl/src/test/java/eu/xenit/contentcloud/thunx/predicates/querydsl/QueryDslUtilsTest.java
+++ b/thunx-predicates-querydsl/src/test/java/eu/xenit/contentcloud/thunx/predicates/querydsl/QueryDslUtilsTest.java
@@ -33,7 +33,22 @@ class QueryDslUtilsTest {
         assertThat(actual)
                 .isNotNull()
                 .hasToString("document.security = 5");
+    }
 
+    @Test
+    void convert_null_comparison() {
+        // document.security == null
+        var thunkExpression = Comparison.areEqual(
+                SymbolicReference.of("entity", path -> path.string("security")),
+                Scalar.nullValue()
+        );
+
+        var document = new PathBuilder(Document.class, "document");
+
+        var actual = QueryDslUtils.from(thunkExpression, document);
+        assertThat(actual)
+                .isNotNull()
+                .hasToString("document.security = null");
     }
 
     @Test


### PR DESCRIPTION
For the NullValue, Scalar#getValue() returns null.
When that is passed into Expressions.constant(value), at some point value.getClass() is called,
which produces a NullPointerException in the case that value is null.

Instead, use the special construct from QueryDSL to represent a IS NULL expression.
This construct correctly handles the translation from 'property = ?' to 'property IS NULL', which is required
for NULL-checks in the database.