### PR TITLE
Fix QueryDSL AND/OR for more than 2 parameters

### DIFF
--- a/thunx-predicates-querydsl/src/test/java/eu/xenit/contentcloud/thunx/predicates/querydsl/QueryDslUtilsTest.java
+++ b/thunx-predicates-querydsl/src/test/java/eu/xenit/contentcloud/thunx/predicates/querydsl/QueryDslUtilsTest.java
@@ -53,14 +53,17 @@ class QueryDslUtilsTest {
 
     @Test
     void convert_disjunction() {
-        // document.security == 5 OR document.security == 10
+        // document.security == 5 OR document.security == 10 OR document.security == 8
         var thunkExpression = LogicalOperation.disjunction(
                 Comparison.areEqual(
                         SymbolicReference.of("entity", path -> path.string("security")),
                         Scalar.of(5)),
                 Comparison.areEqual(
                         SymbolicReference.of("entity", path -> path.string("security")),
-                        Scalar.of(10))
+                        Scalar.of(10)),
+                Comparison.areEqual(
+                        SymbolicReference.of("entity", path -> path.string("security")),
+                        Scalar.of(8))
         );
 
         var document = new PathBuilder(Document.class, "document");
@@ -68,7 +71,7 @@ class QueryDslUtilsTest {
         var actual = QueryDslUtils.from(thunkExpression, document);
         assertThat(actual)
                 .isNotNull()
-                .hasToString("document.security = 5 || document.security = 10");
+                .hasToString("document.security = 5 || document.security = 10 || document.security = 8");
 
     }
 


### PR DESCRIPTION
QueryDSL uses some templates to generate expressions. Passing more than
2 values for AND or OR results in only the first two values being taken
into account, dropping the rest.

Using the proper QueryDSL methods to create the AND/OR expressions will
create a nested set of AND/OR expressions that are working correctly.
