### PR TITLE
Pass ServerWebExchange instead of ServerHttpRequest.

### DIFF
--- a/thunx-autoconfigure/src/main/java/com/contentgrid/thunx/gateway/autoconfigure/GatewayAutoConfiguration.java
+++ b/thunx-autoconfigure/src/main/java/com/contentgrid/thunx/gateway/autoconfigure/GatewayAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.web.server.ServerWebExchange;
 
 @Configuration
 @ConditionalOnClass({OpaClient.class, AbstractGatewayFilterFactory.class})
@@ -37,26 +38,26 @@ public class GatewayAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public OpaQueryProvider<ServerHttpRequest> propertyBasedOpaQueryProvider(OpaProperties opaProperties) {
+    public OpaQueryProvider<ServerWebExchange> propertyBasedOpaQueryProvider(OpaProperties opaProperties) {
         return request -> opaProperties.getQuery();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public OpaInputProvider<Authentication, ServerHttpRequest> defaultOpaInputProvider() {
+    public OpaInputProvider<Authentication, ServerWebExchange> defaultOpaInputProvider() {
         return new DefaultOpaInputProvider();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public PolicyDecisionPointClient<Authentication, ServerHttpRequest> pdpClient(OpaClient opaClient, OpaQueryProvider<ServerHttpRequest> queryProvider, OpaInputProvider<Authentication, ServerHttpRequest> inputProvider) {
+    public PolicyDecisionPointClient<Authentication, ServerWebExchange> pdpClient(OpaClient opaClient, OpaQueryProvider<ServerWebExchange> queryProvider, OpaInputProvider<Authentication, ServerWebExchange> inputProvider) {
         return new OpenPolicyAgentPDPClient<>(opaClient, queryProvider, inputProvider);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public ReactiveAuthorizationManager<AuthorizationContext> reactiveAuthenticationManager(
-            PolicyDecisionPointClient<Authentication, ServerHttpRequest> pdpClient) {
+            PolicyDecisionPointClient<Authentication, ServerWebExchange> pdpClient) {
         return new ReactivePolicyAuthorizationManager(new PolicyDecisionComponentImpl<>(pdpClient));
     }
 

--- a/thunx-autoconfigure/src/test/java/com/contentgrid/thunx/gateway/autoconfigure/GatewayAutoConfigurationTest.java
+++ b/thunx-autoconfigure/src/test/java/com/contentgrid/thunx/gateway/autoconfigure/GatewayAutoConfigurationTest.java
@@ -1,5 +1,8 @@
 package com.contentgrid.thunx.gateway.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
 import com.contentgrid.opa.client.OpaClient;
 import com.contentgrid.thunx.api.autoconfigure.AbacAutoConfiguration;
 import com.contentgrid.thunx.pdp.PolicyDecisionPointClient;
@@ -8,17 +11,13 @@ import com.contentgrid.thunx.spring.gateway.filter.AbacGatewayFilterFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.authorization.AuthorizationContext;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import org.springframework.web.server.ServerWebExchange;
 
 public class GatewayAutoConfigurationTest {
 
@@ -82,7 +81,7 @@ public class GatewayAutoConfigurationTest {
         }
 
         @Bean
-        public PolicyDecisionPointClient<Authentication, ServerHttpRequest> pdpClient() {
+        public PolicyDecisionPointClient<Authentication, ServerWebExchange> pdpClient() {
             return mock(PolicyDecisionPointClient.class);
         }
 
@@ -97,7 +96,7 @@ public class GatewayAutoConfigurationTest {
         }
 
         @Bean
-        public OpaQueryProvider<ServerHttpRequest> customQueryProvider() {
+        public OpaQueryProvider<ServerWebExchange> customQueryProvider() {
             return mock(OpaQueryProvider.class);
         }
     }

--- a/thunx-spring/src/main/java/com/contentgrid/thunx/spring/security/DefaultOpaInputProvider.java
+++ b/thunx-spring/src/main/java/com/contentgrid/thunx/spring/security/DefaultOpaInputProvider.java
@@ -4,10 +4,10 @@ import com.contentgrid.thunx.pdp.opa.OpaInputProvider;
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
 
-public class DefaultOpaInputProvider implements OpaInputProvider<Authentication, ServerHttpRequest> {
+public class DefaultOpaInputProvider implements OpaInputProvider<Authentication, ServerWebExchange> {
 
     static String[] uriToPathArray(URI uri) {
         Objects.requireNonNull(uri, "Argument 'uri' is required");
@@ -30,8 +30,9 @@ public class DefaultOpaInputProvider implements OpaInputProvider<Authentication,
     }
 
     @Override
-    public Map<String, Object> createInput(Authentication authentication, ServerHttpRequest requestContext) {
+    public Map<String, Object> createInput(Authentication authentication, ServerWebExchange webExchange) {
         var authContext = AuthenticationContextMapper.fromAuthentication(authentication);
+        var requestContext = webExchange.getRequest();
         return Map.of(
                 "path", uriToPathArray(requestContext.getURI()),
                 "method", requestContext.getMethodValue(),

--- a/thunx-spring/src/main/java/com/contentgrid/thunx/spring/security/ReactivePolicyAuthorizationManager.java
+++ b/thunx-spring/src/main/java/com/contentgrid/thunx/spring/security/ReactivePolicyAuthorizationManager.java
@@ -2,20 +2,20 @@ package com.contentgrid.thunx.spring.security;
 
 import com.contentgrid.thunx.pdp.PolicyDecision;
 import com.contentgrid.thunx.pdp.PolicyDecisionComponent;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 public class ReactivePolicyAuthorizationManager implements ReactiveAuthorizationManager<AuthorizationContext> {
 
     public static final String ABAC_POLICY_PREDICATE_ATTR = "ABAC_POLICY_PREDICATE";
 
-    private final PolicyDecisionComponent<Authentication, ServerHttpRequest> policyDecisionComponent;
+    private final PolicyDecisionComponent<Authentication, ServerWebExchange> policyDecisionComponent;
 
-    public ReactivePolicyAuthorizationManager(PolicyDecisionComponent<Authentication, ServerHttpRequest> policyDecisionComponent) {
+    public ReactivePolicyAuthorizationManager(PolicyDecisionComponent<Authentication, ServerWebExchange> policyDecisionComponent) {
         this.policyDecisionComponent = policyDecisionComponent;
     }
 
@@ -24,7 +24,7 @@ public class ReactivePolicyAuthorizationManager implements ReactiveAuthorization
             Mono<Authentication> authentication, AuthorizationContext authzContext) {
         return authentication.flatMap(authContext ->
                 {
-                    var policyDecisionFuture = policyDecisionComponent.authorize(authContext, authzContext.getExchange().getRequest());
+                    var policyDecisionFuture = policyDecisionComponent.authorize(authContext, authzContext.getExchange());
                     return Mono.fromCompletionStage(policyDecisionFuture);
                 })
                 .map((PolicyDecision policyDecision) -> {


### PR DESCRIPTION
Sometimes, you need to access the ServerWebExchange attributes instead of only request data, so we should make that possible
