### PR TITLE
Json Encoder implements ThunkExpressionEncoder & ThunkExpressionDecoder interfaces

### DIFF
--- a/thunx-encoding-json/src/main/java/com/contentgrid/thunx/encoding/json/ExpressionJsonConverter.java
+++ b/thunx-encoding-json/src/main/java/com/contentgrid/thunx/encoding/json/ExpressionJsonConverter.java
@@ -1,82 +1,36 @@
 package com.contentgrid.thunx.encoding.json;
 
-import com.contentgrid.thunx.predicates.model.Scalar;
-import com.contentgrid.thunx.predicates.model.SymbolicReference;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
-import com.contentgrid.thunx.predicates.model.ContextFreeThunkExpressionVisitor;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.contentgrid.thunx.predicates.model.FunctionExpression;
-import com.contentgrid.thunx.predicates.model.Variable;
-import java.io.UncheckedIOException;
-import java.util.stream.Collectors;
+import java.nio.charset.StandardCharsets;
 
+/**
+ * @deprecated use the {@link JsonThunkExpressionCoder} instead
+ */
+@Deprecated(forRemoval = true, since = "0.10.1")
 public class ExpressionJsonConverter {
 
-    private final ObjectMapper objectMapper;
-    private final JsonEncoderVisitor visitor = new JsonEncoderVisitor();
+    private final JsonThunkExpressionCoder coder;
+
 
     public ExpressionJsonConverter() {
         this(new ObjectMapper());
     }
 
     public ExpressionJsonConverter(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+        this.coder = new JsonThunkExpressionCoder(objectMapper);
     }
 
     public String encode(ThunkExpression<?> expression) {
-        try {
-            JsonExpressionDto jsonDto = expression.accept(this.visitor, null);
-            return this.objectMapper.writeValueAsString(jsonDto);
-        } catch (JsonProcessingException e) {
-            throw new UncheckedIOException(e);
-        }
+        return new String(coder.encode(expression.assertResultType(Boolean.class)), StandardCharsets.UTF_8);
     }
 
-    public ThunkExpression<?> decode(String json) throws JsonProcessingException, InvalidExpressionDataException {
-        var dto = this.objectMapper.readValue(json, JsonExpressionDto.class);
 
-        return dto.toExpression();
+    public ThunkExpression<?> decode(String json) throws InvalidExpressionDataException {
+        return this.coder.decode(json.getBytes(StandardCharsets.UTF_8));
 
     }
 
-    private static class JsonEncoderVisitor extends ContextFreeThunkExpressionVisitor<JsonExpressionDto> {
-
-        @Override
-        public JsonExpressionDto visit(Scalar<?> scalar) {
-            var resultType = scalar.getResultType();
-
-            var typeName = JsonScalarDto.SCALAR_TYPES.get(resultType);
-            if (typeName == null) {
-                String exMessage = String.format("Scalar of type <%s> is not supported", resultType.getName());
-                throw new IllegalArgumentException(exMessage);
-            }
-
-            return JsonScalarDto.of(typeName, scalar.getValue());
-        }
-
-        @Override
-        public JsonExpressionDto visit(FunctionExpression<?> functionExpression) {
-            var operator = functionExpression.getOperator();
-            var result = functionExpression.getTerms().stream().map(term -> term.accept(this, null));
-
-
-            return new JsonFunctionDto(operator.getKey(), result);
-        }
-
-        @Override
-        public JsonExpressionDto visit(SymbolicReference ref) {
-            var jsonExprTerms = ref.getPath().stream().map(p -> p.accept(this)).collect(Collectors.toList());
-            return new JsonSymbolicReferenceDto(ref.getSubject().accept(this, null), jsonExprTerms);
-        }
-
-        @Override
-        public JsonExpressionDto visit(Variable variable) {
-            return new JsonVariableDto(variable.getName());
-        }
-
-
-    }
 
 
 }

--- a/thunx-encoding-json/src/main/java/com/contentgrid/thunx/encoding/json/JsonFunctionDto.java
+++ b/thunx-encoding-json/src/main/java/com/contentgrid/thunx/encoding/json/JsonFunctionDto.java
@@ -1,6 +1,5 @@
 package com.contentgrid.thunx.encoding.json;
 
-import com.contentgrid.thunx.predicates.model.FunctionExpression;
 import com.contentgrid.thunx.predicates.model.FunctionExpression.Operator;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 import java.util.ArrayList;

--- a/thunx-encoding-json/src/main/java/com/contentgrid/thunx/encoding/json/JsonThunkExpressionCoder.java
+++ b/thunx-encoding-json/src/main/java/com/contentgrid/thunx/encoding/json/JsonThunkExpressionCoder.java
@@ -1,0 +1,107 @@
+package com.contentgrid.thunx.encoding.json;
+
+import com.contentgrid.thunx.encoding.ThunkExpressionDecoder;
+import com.contentgrid.thunx.encoding.ThunkExpressionEncoder;
+import com.contentgrid.thunx.predicates.model.ContextFreeThunkExpressionVisitor;
+import com.contentgrid.thunx.predicates.model.FunctionExpression;
+import com.contentgrid.thunx.predicates.model.Scalar;
+import com.contentgrid.thunx.predicates.model.SymbolicReference;
+import com.contentgrid.thunx.predicates.model.ThunkExpression;
+import com.contentgrid.thunx.predicates.model.Variable;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * JSON encoder and decoder for thunx expressions
+ * @since 0.10.1
+ */
+@RequiredArgsConstructor
+public class JsonThunkExpressionCoder implements ThunkExpressionEncoder, ThunkExpressionDecoder {
+    private final ObjectMapper objectMapper;
+    private static final JsonEncoderVisitor visitor = new JsonEncoderVisitor();
+
+    public JsonThunkExpressionCoder() {
+        this(new ObjectMapper());
+    }
+
+    public ThunkExpression<?> decodeFromJson(JsonNode node) throws JsonProcessingException {
+        return this.objectMapper.treeToValue(node, JsonExpressionDto.class)
+                .toExpression();
+    }
+
+    /**
+     * @deprecated use {@link #decode(byte[])} instead
+     */
+    @Override
+    @Deprecated(forRemoval = true, since = "0.10.1")
+    public ThunkExpression<Boolean> decoder(byte[] data) {
+        return decode(data);
+    }
+
+    @Override
+    public ThunkExpression<Boolean> decode(byte[] data) {
+        try {
+            return decodeFromJson(this.objectMapper.readTree(data))
+                    .assertResultType(Boolean.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public JsonNode encodeToJson(ThunkExpression<?> expression) {
+        var jsonDto = expression.accept(visitor, null);
+        return this.objectMapper.valueToTree(jsonDto);
+    }
+
+    @Override
+    public byte[] encode(ThunkExpression<Boolean> expression) {
+        try {
+            return this.objectMapper.writeValueAsBytes(encodeToJson(expression));
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static class JsonEncoderVisitor extends ContextFreeThunkExpressionVisitor<JsonExpressionDto> {
+
+        @Override
+        public JsonExpressionDto visit(Scalar<?> scalar) {
+            var resultType = scalar.getResultType();
+
+            var typeName = JsonScalarDto.SCALAR_TYPES.get(resultType);
+            if (typeName == null) {
+                String exMessage = String.format("Scalar of type <%s> is not supported", resultType.getName());
+                throw new IllegalArgumentException(exMessage);
+            }
+
+            return JsonScalarDto.of(typeName, scalar.getValue());
+        }
+
+        @Override
+        public JsonExpressionDto visit(FunctionExpression<?> functionExpression) {
+            var operator = functionExpression.getOperator();
+            var result = functionExpression.getTerms().stream().map(term -> term.accept(this, null));
+
+
+            return new JsonFunctionDto(operator.getKey(), result);
+        }
+
+        @Override
+        public JsonExpressionDto visit(SymbolicReference ref) {
+            var jsonExprTerms = ref.getPath().stream().map(p -> p.accept(this)).collect(Collectors.toList());
+            return new JsonSymbolicReferenceDto(ref.getSubject().accept(this, null), jsonExprTerms);
+        }
+
+        @Override
+        public JsonExpressionDto visit(Variable variable) {
+            return new JsonVariableDto(variable.getName());
+        }
+
+
+    }
+}

--- a/thunx-integration-tests/api-integration-tests/src/test/java/com/contentgrid/thunx/example/demo/ThunxDemoApplicationTests.java
+++ b/thunx-integration-tests/api-integration-tests/src/test/java/com/contentgrid/thunx/example/demo/ThunxDemoApplicationTests.java
@@ -24,6 +24,7 @@ import com.contentgrid.spring.test.fixture.invoicing.repository.OrderRepository;
 import com.contentgrid.spring.test.fixture.invoicing.repository.PromotionCampaignRepository;
 import com.contentgrid.spring.test.fixture.invoicing.repository.ShippingAddressRepository;
 import com.contentgrid.thunx.encoding.json.ExpressionJsonConverter;
+import com.contentgrid.thunx.encoding.json.JsonThunkExpressionCoder;
 import com.contentgrid.thunx.predicates.model.BooleanOperation;
 import com.contentgrid.thunx.predicates.model.Comparison;
 import com.contentgrid.thunx.predicates.model.LogicalOperation;
@@ -912,8 +913,7 @@ class ThunxDemoApplicationTests {
     }
 
     private static String headerEncode(ThunkExpression<Boolean> expression) {
-
-        var bytes = new ExpressionJsonConverter().encode(expression).getBytes(StandardCharsets.UTF_8);
+        var bytes = new JsonThunkExpressionCoder().encode(expression);
         return Base64.getEncoder().encodeToString(bytes);
     }
 

--- a/thunx-model/src/main/java/com/contentgrid/thunx/encoding/ThunkExpressionDecoder.java
+++ b/thunx-model/src/main/java/com/contentgrid/thunx/encoding/ThunkExpressionDecoder.java
@@ -6,5 +6,14 @@ import com.contentgrid.thunx.predicates.model.ThunkExpression;
 public
 interface ThunkExpressionDecoder {
 
+    /**
+     * @deprecated use {@link #decode(byte[])} instead
+     */
+    @Deprecated(forRemoval = true, since = "0.10.1")
     ThunkExpression<Boolean> decoder(byte[] data);
+
+    @SuppressWarnings("deprecation")
+    default ThunkExpression<Boolean> decode(byte[] data) {
+        return this.decoder(data);
+    }
 }

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacConfiguration.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacConfiguration.java
@@ -1,14 +1,10 @@
 package com.contentgrid.thunx.spring.data.rest;
 
 import com.contentgrid.thunx.encoding.ThunkExpressionDecoder;
-import com.contentgrid.thunx.encoding.json.ExpressionJsonConverter;
-import com.contentgrid.thunx.predicates.model.ThunkExpression;
+import com.contentgrid.thunx.encoding.json.JsonThunkExpressionCoder;
 import com.contentgrid.thunx.spring.data.querydsl.AbacQuerydslPredicateResolver;
 import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.repository.RepositoryInvokerAdapterFactory;
 import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.QuerydslPredicateResolver;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
@@ -30,16 +26,7 @@ public class AbacConfiguration {
 
     @Bean
     public ThunkExpressionDecoder thunkDecoder() {
-        return data -> {
-            try {
-                var json = new String(data, StandardCharsets.UTF_8);
-                var expression = new ExpressionJsonConverter().decode(json);
-
-                return ((ThunkExpression<Boolean>) expression);
-            } catch (JsonProcessingException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
+        return new JsonThunkExpressionCoder();
     }
 
     @Bean

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
@@ -33,7 +33,7 @@ public class AbacRequestFilter implements Filter {
         if (abacContext != null) {
             byte[] abacContextBytes = Base64.getDecoder().decode(abacContext);
             // which (version of?) decoder should we use ? -> get that info from JWT or other header ?
-            ThunkExpression<Boolean> abacExpression = this.thunkDecoder.decoder(abacContextBytes);
+            ThunkExpression<Boolean> abacExpression = this.thunkDecoder.decode(abacContextBytes);
             log.debug("ABAC Context: {}", abacExpression);
             AbacContext.setCurrentAbacContext(abacExpression);
         } else {

--- a/thunx-spring-gateway/src/main/java/com/contentgrid/thunx/spring/gateway/filter/AbacGatewayFilterFactory.java
+++ b/thunx-spring-gateway/src/main/java/com/contentgrid/thunx/spring/gateway/filter/AbacGatewayFilterFactory.java
@@ -1,10 +1,9 @@
 package com.contentgrid.thunx.spring.gateway.filter;
 
 import com.contentgrid.thunx.encoding.ThunkExpressionEncoder;
+import com.contentgrid.thunx.encoding.json.JsonThunkExpressionCoder;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 import com.contentgrid.thunx.spring.security.ReactivePolicyAuthorizationManager;
-import com.contentgrid.thunx.encoding.json.ExpressionJsonConverter;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -37,7 +36,7 @@ public class AbacGatewayFilterFactory extends AbstractGatewayFilterFactory<AbacG
     private final ThunkExpressionEncoder encoder;
 
     public AbacGatewayFilterFactory() {
-        this(expression -> new ExpressionJsonConverter().encode(expression).getBytes(StandardCharsets.UTF_8));
+        this(new JsonThunkExpressionCoder());
     }
 
     public AbacGatewayFilterFactory(ThunkExpressionEncoder encoder) {


### PR DESCRIPTION
Instead of writing ad-hoc functions for implementing ThunkExpressionEncoder and ThunkExpressionDecoder using the ExpressionJsonConverter,
replace it with a new JsonThunkExpressionCoder that directly implements both interfaces.

To maintain backwards compatibility, it is not possible for ExpressionJsonConverter to implement those interfaces, as methods with the
same name and parameter types can not have a different return type.
Because of this, ExpressionJsonConverter is now deprecated for removal in the next major version.
