### PR TITLE
[ACC-1451] Throw exception if abac context is missing

### DIFF
--- a/thunx-integration-tests/api-integration-tests/src/test/java/com/contentgrid/thunx/example/demo/ThunxDemoApplicationTests.java
+++ b/thunx-integration-tests/api-integration-tests/src/test/java/com/contentgrid/thunx/example/demo/ThunxDemoApplicationTests.java
@@ -52,7 +52,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @Transactional
 @AutoConfigureMockMvc(printOnlyOnFailure = false)
-@SpringBootTest(classes = InvoicingApplication.class)
+@SpringBootTest(classes = InvoicingApplication.class, properties = "contentgrid.thunx.allow-missing-abac=false")
 @WithMockJwt
 class ThunxDemoApplicationTests {
 
@@ -152,7 +152,7 @@ class ThunxDemoApplicationTests {
             void listInvoices_noPolicy_shouldFail_http500() {
                 assertThatThrownBy(() -> mockMvc.perform(get("/invoices")
                                 .contentType("application/json")), "No X-ABAC-Context context present.")
-                        .isInstanceOf(IllegalStateException.class);
+                        .isInstanceOf(IllegalArgumentException.class);
             }
 
             @Test
@@ -246,7 +246,7 @@ class ThunxDemoApplicationTests {
 
                 assertThatThrownBy(() -> mockMvc.perform(get("/invoices/" + invoiceIdByNumber(INVOICE_1))
                                 .contentType("application/json")), "No X-ABAC-Context context present.")
-                        .isInstanceOf(IllegalStateException.class);
+                        .isInstanceOf(IllegalArgumentException.class);
             }
 
             @Test

--- a/thunx-integration-tests/api-integration-tests/src/test/java/com/contentgrid/thunx/example/demo/ThunxDemoApplicationTests.java
+++ b/thunx-integration-tests/api-integration-tests/src/test/java/com/contentgrid/thunx/example/demo/ThunxDemoApplicationTests.java
@@ -1,6 +1,7 @@
 package com.contentgrid.thunx.example.demo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.endsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -24,7 +25,6 @@ import com.contentgrid.spring.test.fixture.invoicing.repository.OrderRepository;
 import com.contentgrid.spring.test.fixture.invoicing.repository.PromotionCampaignRepository;
 import com.contentgrid.spring.test.fixture.invoicing.repository.ShippingAddressRepository;
 import com.contentgrid.spring.test.security.WithMockJwt;
-import com.contentgrid.thunx.encoding.json.ExpressionJsonConverter;
 import com.contentgrid.thunx.encoding.json.JsonThunkExpressionCoder;
 import com.contentgrid.thunx.predicates.model.BooleanOperation;
 import com.contentgrid.thunx.predicates.model.Comparison;
@@ -33,7 +33,6 @@ import com.contentgrid.thunx.predicates.model.Scalar;
 import com.contentgrid.thunx.predicates.model.SymbolicReference;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 import jakarta.transaction.Transactional;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
@@ -150,11 +149,10 @@ class ThunxDemoApplicationTests {
         class Get {
 
             @Test
-            void listInvoices_noPolicy() throws Exception {
-                mockMvc.perform(get("/invoices")
-                                .contentType("application/json"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.item.length()").value(2));
+            void listInvoices_noPolicy_shouldFail_http500() {
+                assertThatThrownBy(() -> mockMvc.perform(get("/invoices")
+                                .contentType("application/json")), "No X-ABAC-Context context present.")
+                        .isInstanceOf(IllegalStateException.class);
             }
 
             @Test
@@ -244,12 +242,11 @@ class ThunxDemoApplicationTests {
         class Get {
 
             @Test
-            void getInvoice_policyNone_shouldReturn_http200_ok() throws Exception {
+            void getInvoice_policyNone_shouldFail_http500() {
 
-                mockMvc.perform(get("/invoices/" + invoiceIdByNumber(INVOICE_1))
-                                .contentType("application/json"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.number").value(INVOICE_1));
+                assertThatThrownBy(() -> mockMvc.perform(get("/invoices/" + invoiceIdByNumber(INVOICE_1))
+                                .contentType("application/json")), "No X-ABAC-Context context present.")
+                        .isInstanceOf(IllegalStateException.class);
             }
 
             @Test

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacConfiguration.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacConfiguration.java
@@ -8,8 +8,8 @@ import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.Qu
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationContext;
@@ -25,9 +25,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Configuration
 public class AbacConfiguration {
 
-    @Autowired
-    ApplicationContext applicationContext;
-
     @Bean
     public ThunkExpressionDecoder thunkDecoder() {
         return new JsonThunkExpressionCoder();
@@ -39,9 +36,8 @@ public class AbacConfiguration {
     }
 
     @Bean
-    public AbacRequestFilter abacFilter(ThunkExpressionDecoder thunkDecoder) {
-        var allowMissingAbac = applicationContext.getEnvironment()
-                .getProperty("contentgrid.thunx.allow-missing-abac", boolean.class, false);
+    public AbacRequestFilter abacFilter(ThunkExpressionDecoder thunkDecoder,
+            @Value("${contentgrid.thunx.allow-missing-abac:false}") boolean allowMissingAbac) {
         return new AbacRequestFilter(thunkDecoder, allowMissingAbac);
     }
 

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacConfiguration.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacConfiguration.java
@@ -8,6 +8,7 @@ import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.Qu
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -24,6 +25,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Configuration
 public class AbacConfiguration {
 
+    @Autowired
+    ApplicationContext applicationContext;
+
     @Bean
     public ThunkExpressionDecoder thunkDecoder() {
         return new JsonThunkExpressionCoder();
@@ -36,7 +40,9 @@ public class AbacConfiguration {
 
     @Bean
     public AbacRequestFilter abacFilter(ThunkExpressionDecoder thunkDecoder) {
-        return new AbacRequestFilter(thunkDecoder);
+        var allowMissingAbac = applicationContext.getEnvironment()
+                .getProperty("contentgrid.thunx.allow-missing-abac", boolean.class, false);
+        return new AbacRequestFilter(thunkDecoder, allowMissingAbac);
     }
 
     @Bean

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
@@ -17,9 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 public class AbacRequestFilter implements Filter {
 
     private final ThunkExpressionDecoder thunkDecoder;
+    private final boolean allowMissingAbac;
 
-    public AbacRequestFilter(ThunkExpressionDecoder thunkDecoder) {
+    public AbacRequestFilter(ThunkExpressionDecoder thunkDecoder, boolean allowMissingAbac) {
         this.thunkDecoder = thunkDecoder;
+        this.allowMissingAbac = allowMissingAbac;
     }
 
     @Override
@@ -37,7 +39,11 @@ public class AbacRequestFilter implements Filter {
             log.debug("ABAC Context: {}", abacExpression);
             AbacContext.setCurrentAbacContext(abacExpression);
         } else {
-            log.warn("No X-ABAC-Context context present.");
+            var message = "No X-ABAC-Context context present.";
+            log.warn(message);
+            if (!allowMissingAbac) {
+                throw new IllegalStateException(message);
+            }
         }
 
         filterChain.doFilter(servletRequest, servletResponse);

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
@@ -42,7 +42,7 @@ public class AbacRequestFilter implements Filter {
             var message = "No X-ABAC-Context context present.";
             log.warn(message);
             if (!allowMissingAbac) {
-                throw new IllegalStateException(message);
+                throw new IllegalArgumentException(message);
             }
         }
 


### PR DESCRIPTION
For local bootRun, the property to disable this behavior is `contentgrid.thunx.allow-missing-abac=true`