### PR TITLE
Make AbacContext package-private to avoid misuse to retrieve the ABAC Context

### DIFF
--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/querydsl/AbacQuerydslPredicateResolver.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/querydsl/AbacQuerydslPredicateResolver.java
@@ -2,7 +2,6 @@ package com.contentgrid.thunx.spring.data.querydsl;
 
 import com.contentgrid.thunx.predicates.querydsl.FieldByReflectionAccessStrategy;
 import com.contentgrid.thunx.predicates.querydsl.QueryDslConverter;
-import com.contentgrid.thunx.spring.data.context.AbacContext;
 import com.contentgrid.thunx.spring.data.context.AbacContextSupplier;
 import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.OperationPredicates;
 import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.QuerydslPredicateResolver;
@@ -15,7 +14,7 @@ import org.springframework.data.querydsl.EntityPathResolver;
 import org.springframework.util.Assert;
 
 /**
- * Resolves the QueryDSL Predicate from the Thunx {@link AbacContext} that is sent with the request
+ * Resolves the QueryDSL Predicate from the Thunx {@link AbacContextSupplier}
  */
 @Slf4j
 public class AbacQuerydslPredicateResolver implements QuerydslPredicateResolver {

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacContext.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacContext.java
@@ -1,8 +1,8 @@
-package com.contentgrid.thunx.spring.data.context;
+package com.contentgrid.thunx.spring.data.rest;
 
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 
-public class AbacContext {
+class AbacContext {
 
     private static ThreadLocal<ThunkExpression<Boolean>> currentAbacContext = new InheritableThreadLocal<ThunkExpression<Boolean>>();
 

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/AbacRequestFilter.java
@@ -1,6 +1,5 @@
 package com.contentgrid.thunx.spring.data.rest;
 
-import com.contentgrid.thunx.spring.data.context.AbacContext;
 import com.contentgrid.thunx.encoding.ThunkExpressionDecoder;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 import java.io.IOException;

--- a/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/HttpHeaderAbacConfiguration.java
+++ b/thunx-spring-api/src/main/java/com/contentgrid/thunx/spring/data/rest/HttpHeaderAbacConfiguration.java
@@ -1,7 +1,6 @@
 package com.contentgrid.thunx.spring.data.rest;
 
 import com.contentgrid.thunx.encoding.ThunkExpressionDecoder;
-import com.contentgrid.thunx.spring.data.context.AbacContext;
 import com.contentgrid.thunx.spring.data.context.AbacContextSupplier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
Since the introduction of a way to provide abac context with a JWT, using AbacContext directly is no longer guaranteed to always contain the ABAC context
