### PR TITLE
Revert "Update dependency org.springframework.boot:spring-boot-dependencies to v3.4.3"

### DIFF
--- a/thunx-dependencies/build.gradle
+++ b/thunx-dependencies/build.gradle
@@ -9,7 +9,7 @@ javaPlatform {
 dependencies {
     api platform(project(":thunx-bom"))
 
-    api platform("org.springframework.boot:spring-boot-dependencies:3.4.3")
+    api platform("org.springframework.boot:spring-boot-dependencies:3.4.2")
     api platform("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
 
     constraints {

--- a/thunx-integration-tests/api-integration-tests/build.gradle
+++ b/thunx-integration-tests/api-integration-tests/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-	implementation platform("org.springframework.boot:spring-boot-dependencies:3.4.3")
+	implementation platform("org.springframework.boot:spring-boot-dependencies:3.4.2")
 	implementation platform(project(":thunx-bom"))
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'


### PR DESCRIPTION
Reverts xenit-eu/thunx#219, needed because of https://github.com/spring-projects/spring-framework/issues/34423