### PR TITLE
ACC-3084: fix publishing thunx-bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,14 @@ allprojects {
     }
 
     pluginManager.withPlugin('maven-publish') {
+        // The nmcp plugin (applied together with maven-publish) resolves its
+        // 'nmcpTasks' configuration from the project repositories. Non-java-library
+        // publishing projects (e.g. the java-platform bom) don't get repositories
+        // from the java-library block above, so declare one here.
+        repositories {
+            mavenCentral()
+        }
+
         apply from: "${rootDir}/gradle/publish.gradle"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,6 @@ allprojects {
 
         repositories {
             mavenCentral()
-            maven {
-                url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-                content {
-                    includeGroup 'com.contentgrid.opa-java-client'
-                }
-            }
         }
     }
 


### PR DESCRIPTION
`thunx-bom` doesn't apply `java-library`, so it also doesn't define `mavenCentral` repository from the `java-library` block. Define the `mavenCentral` repository for projects with `maven-publish` as well, so that nmcp can resolve its dependencies.