### PR TITLE
ACC-3084: fix publishing with nmcp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,21 +24,9 @@ allprojects {
             withSourcesJar()
             withJavadocJar()
         }
-
-        repositories {
-            mavenCentral()
-        }
     }
 
     pluginManager.withPlugin('maven-publish') {
-        // The nmcp plugin (applied together with maven-publish) resolves its
-        // 'nmcpTasks' configuration from the project repositories. Non-java-library
-        // publishing projects (e.g. the java-platform bom) don't get repositories
-        // from the java-library block above, so declare one here.
-        repositories {
-            mavenCentral()
-        }
-
         apply from: "${rootDir}/gradle/publish.gradle"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,11 @@ reckon {
     stageCalc = { inventory, targetNormal -> java.util.Optional.empty() }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
 
 include 'thunx-dependencies'
 


### PR DESCRIPTION
Build failed because root thunx project didn't have a `dependencies` block (it was only applied to sub-projects).
Nmcp always needs a `dependencies` block, so move it into a `dependencyResolutionManagement` block (like in contentgrid-appserver).